### PR TITLE
Implement ":results value" for Python

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -13,9 +13,8 @@ This package is still in an experimental stage, and not available in MELPA.
 However, the code is fairly robust now, and I am using it regularly for my
 day-to-day data analysis in R.
 
-Currently, we have implemented async session evaluation for R and
-Ruby. We have partial support for Python (we support =:results
-output=, but NOT =:results value=).
+Currently, we have implemented async session evaluation for R, Ruby,
+and Python.
 
 The org-mode mailing list has expressed some interest in including
 this code in org-mode ([[https://lists.gnu.org/archive/html/emacs-orgmode/2019-08/msg00191.html][thread]]), and a long-term goal of the project is
@@ -23,7 +22,9 @@ to contribute this functionality back upstream to org-mode.
 
 * Installation & usage
 
-First ensure the ~lisp/~ directory is in your ~load-path~, and ~R~ is
+First, make sure you have installed the latest Org release (9.4).
+
+Next ensure the ~lisp/~ directory is in your ~load-path~, and ~R~ is
 in ~org-babel-load-languages~. Then, ~(require
 'ob-session-async-R)~. You will then be able to asynchronously
 evaluate R code blocks like the below:

--- a/lisp/ob-session-async-python.el
+++ b/lisp/ob-session-async-python.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2019
 
 ;; Author:  <jackkamm@gmail.com>
+;; Package-Requires: ((org "9.4"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -72,22 +73,11 @@ by `ob-session-async-filter'."
            (python-shell-send-buffer))
          uuid))
       (`value
-       ;; TODO: require dependancy of Org 9.4 (not yet released as of 2020-02-15)
        (let ((tmp-results-file (org-babel-temp-file "python-"))
              (tmp-src-file (org-babel-temp-file "python-")))
          (with-temp-file tmp-src-file (insert body))
          (with-temp-buffer
-           (insert (format org-babel-python--eval-ast tmp-src-file))
-           (insert (format (if (member "pp" result-params)
-                               "
-import pprint
-with open('%s', 'w') as f:
-    f.write(pprint.pformat(__org_babel_python_final))"
-                             "
-with open('%s', 'w') as f:
-    f.write(str(__org_babel_python_final))")
-                           (org-babel-process-file-name
-                            tmp-results-file 'noquote)))
+           (insert (org-babel-python-format-session-value tmp-src-file tmp-results-file result-params))
            (insert "\n")
            (insert (format ob-session-async-python-indicator "file" tmp-results-file))
            (python-shell-send-buffer))


### PR DESCRIPTION
Requires Org 9.4, not yet released as of 2020-02-15.

TODO: Add unit tests, update Readme & note dependency on Org 9.4